### PR TITLE
Concent form checkboxes

### DIFF
--- a/app/assets/stylesheets/client.css
+++ b/app/assets/stylesheets/client.css
@@ -8,6 +8,10 @@ label.error {
   color: red;
 }
 
+label{
+  font-weight: normal;
+}
+
 #contact{
   padding:10px 0 10px;
 }

--- a/app/views/clients/new.html.erb
+++ b/app/views/clients/new.html.erb
@@ -101,7 +101,7 @@
         <li class="list-group-item d-flex justify-content-between lh-condensed">
           <a href="/Clinic_Informed_Consent_and_PDS.pdf" class="btn btn-primary" style="color: white; width: 300px">Informed Consent for Counseling</a>
           <label>I consent</label>
-          <%= form.check_box :accepted, id: :counselingConsent, checked: false %>
+          <%= form.check_box :accepted, id: :counselingConsent, checked: false, required: true %>
         </li>
         <li class="list-group-item d-flex justify-content-between lh-condensed">
           <a href="/IntakeTemplateForWrite-Up.pdf" class="btn btn-primary" style="color: white; width: 300px">Informed Consent for Treatment</a>

--- a/app/views/clients/new.html.erb
+++ b/app/views/clients/new.html.erb
@@ -31,9 +31,9 @@
           </div>
           <div class="checkboxes">
             <span>
-              <label style="font-weight: normal">Yes</label>
+              <label>Yes</label>
               <%= form.check_box :leave_message, id: :client_leave_message %>
-              <label style="font-weight: normal">No</label>
+              <label>No</label>
               <input type="checkbox" class="form-check-input">
             </span>
           </div>
@@ -50,9 +50,9 @@
           </div>
           <div class="checkboxes">
             <span>
-              <label style="font-weight: normal">Yes</label>
+              <label>Yes</label>
               <%= form.check_box :email_leave_message, id: :client_email_leave_message %>
-              <label style="font-weight: normal">No</label>
+              <label>No</label>
               <input type="checkbox" class="form-check-input">
             </span>
           </div>
@@ -99,21 +99,19 @@
       </h4>
       <ul class="list-group mb-3">
         <li class="list-group-item d-flex justify-content-between lh-condensed">
-          <div>
-            <h6 class="my-0">I agree to the following conscent forms:</h6>
-          </div>
-        </li>
-        <li class="list-group-item d-flex justify-content-between lh-condensed">
           <a href="/Clinic_Informed_Consent_and_PDS.pdf" class="btn btn-primary" style="color: white; width: 300px">Informed Consent for Counseling</a>
-          <input id="checkBox" type="checkbox" checked>
+          <label>I consent</label>
+          <%= form.check_box :accepted, id: :counselingConsent, checked: false %>
         </li>
         <li class="list-group-item d-flex justify-content-between lh-condensed">
           <a href="/IntakeTemplateForWrite-Up.pdf" class="btn btn-primary" style="color: white; width: 300px">Informed Consent for Treatment</a>
-          <input id="checkBox" type="checkbox" checked>
+          <label>I consent</label>
+          <%= form.check_box :treatment, id: :treatmentConsent, checked: false %>
         </li>
         <li class="list-group-item d-flex justify-content-between lh-condensed">
           <a href="/Informed_Consent_to_Record.pdf" class="btn btn-primary" id="av_consent">Informed Consent for Video/Audio Recording</a>
-          <input id="checkBox" type="checkbox" checked>
+          <label>I consent</label>
+          <%= form.check_box :av, id: :avConsent, checked: false %>
         </li>
       </ul>
     </div>
@@ -230,9 +228,9 @@
               <div class="input-group">
                 <div class="checkboxes">
                   <span>
-                    <label style="font-weight: normal">Yes</label>
+                    <label>Yes</label>
                     <%= form.check_box :counselor_seen_before, id: :client_counselor_seen_before %>
-                    <label style="font-weight: normal">No</label>
+                    <label>No</label>
                     <input type="checkbox" class="form-check-input">
                   </span>
                 </div>

--- a/test/system/clients_test.rb
+++ b/test/system/clients_test.rb
@@ -25,6 +25,9 @@ class ClientsTest < ApplicationSystemTestCase
     fill_in 'client_sexual_orientation', with: 'Straight'
     fill_in 'client_relationship', with: 'single'
     uncheck 'client_counselor_seen_before'
+    check 'counselingConsent'
+    check 'treatmentConsent'
+    check 'avConsent'
     find('input[type="submit"]').click
 
     assert(has_text?('Client was successfully created.'))


### PR DESCRIPTION
#### What does this PR do?
This PR adds an `I consent` label to the consent form check boxes. It also makes the consent for counseling a required field. Minor style changes, and updated system test.
##### What are the relevant stories?
Issue #157
#### Where should a reviewer start?
The bulk of the work was done in `app/views/clients/new.html.erb`
#### Are there any manual testing steps?
Pull the branch down, run the tests `bundle exec rake test` and `bundle exec rake test:system`. 
Fill the form out yourself and make sure the consent for counseling checkbox is required.